### PR TITLE
remove config as code and add initial user

### DIFF
--- a/charts/infra-server/README.md
+++ b/charts/infra-server/README.md
@@ -42,98 +42,6 @@ This chart can be customized by configuring Helm values. See [Customizing the Ch
 
 For a complete list of customization options, see `helm show values infrahq/infra-server`.
 
-### Users
-
-Add users to Infra. Each user should set a `name`, which should be a valid email address, and may set a password or access key. Passwords and access keys may be set in plaintext or set to a reference to a file or environment variable.
-
-Access keys must be in the form of XXXXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYY (10-length ASCII key followed by 24-length ASCII secret separated by a period).
-
-```yaml
-# example values.yaml
----
-config:
-  users:
-    # Add user without password or access key
-    - name: admin@example.com
-
-    # Add user with a plaintext password
-    - name: admin@example.com
-      password: SetThisPassword!
-
-    # Add user with a plaintext access key
-    - name: admin@example.com
-      accessKey: 123bogusab.abcdefnotreal123key456AB
-
-    # Add a user setting the password using a file. The password should be the only contents of the file. The
-    # file will need to be mounted into the pod using `volumes` and `volumeMounts`.
-    - name: admin@example.com
-      password: file:/var/run/secrets/admin@example.com
-
-    # Add a user setting the access key using a file. The access key should be the only contents of the file. The
-    # file will need to be mounted into the pod using `volumes` and `volumeMounts`.
-    - name: admin@example.com
-      accessKey: file:/var/run/secrets/admin@example.com
-
-    # Add a user setting the password with an environment variable. The environment variable will need to be
-    # injected into the pod using `env` or `envFrom`.
-    - name: admin@example.com
-      password: env:ADMIN_PASSWORD
-
-    # Add a user setting the access key with an environment variable. The environment variable will need to be
-    # injected into the pod using `env` or `envFrom`.
-    - name: admin@example.com
-      accessKey: env:ACCESS_KEY
-```
-
-### Grants
-
-Add a grant for a user or group to a resource. A resource is either `infra`, for setting roles within Infra, or the name of a Kubernetes cluster.
-
-Infra roles can be either `admin`, for full access, or `view`, for limited readonly access.
-
-Kubernetes roles can be any Kubernetes ClusterRole known to Infra. See [Working with Roles](https://infrahq.com/docs/manage/roles) for more details.
-
-```yaml
-# example values.yaml
----
-config:
-  grants:
-    # Add user as an Infra admin
-    - user: admin@example.com
-      role: admin
-      resource: infra
-
-    # Add user as a Kubernetes admin
-    - user: admin@example.com
-      role: admin
-      resource: example-cluster
-
-    # Add user as a Kubernetes edit in the web namespace
-    - user: user@example.com
-      role: edit
-      resource: example-cluster.web
-
-    # Add group as a Kubernetes view
-    - group: Everyone
-      role: view
-      resource: example-cluster
-```
-
-### Identity provider
-
-Add an identity provider (IdP). Supported IdPs include [Okta](https://infrahq.com/docs/manage/idp/okta), [Google](https://infrahq.com/docs/manage/idp/google), [Azure AD](https://infrahq.com/docs/manage/idp/azure-ad), and any generic [OIDC](https://infrahq.com/docs/manage/idp/oidc) provider.
-
-```yaml
-# example values.yaml
----
-config:
-  providers:
-    - name: Okta
-      url: example.okta.com
-      clientID: exampleClientID
-      clientSecret: examplePlaintextSecret
-```
-
 ### External database
 
 Configure an external PostgreSQL database instead of using the one deployed with the chart. Setting these options will omit the included database from being deployed.
@@ -166,9 +74,11 @@ Values for the `infra` chart are incompatible with values for this chart and mus
 * `connector` has been removed. Use the `infrahq/infra` chart instead
 * `global.image` has been removed. Use `server.image`, `ui.image`, or `postgres.image` instead
 * `server.config` has been renamed to `config`, e.g. `server.config.dbHost` is not `config.dbHost`
-* `server.additionalUsers`, `server.additionalProviders`, `server.additionalGrants` has been removed
+* `server.additionalUsers`, `server.additionalProviders`, `server.additionalGrants`, `server.additionalSecrets` has been removed
 * `server.persistence` has been removed
 * Default `server.service.type` value has been changed to `ClusterIP` instead of `LoadBalancer`
+* `server.users`, `server.providers`, `server.grants`, `server.secrets` has been removed. Users are encouraged to move configurations over to [Terraform Infra provider](https://registry.terraform.io/providers/infrahq/infra). **Any users, grants, or identity provider created by server configurations _will be removed_**
+    * An initial admin user can be enabled (default) with `config.admin.enabled`. This creates a user `admin@local` with a randomly generated password which can be used to bootstrap a deployment. Setting `config.admin.enabled=false` disables this user.
 
 _Note: The label value for `app.kubernetes.io/name` has changed. Since this label is used as a selector, the field is immutable. In order to perform an in-place upgrade, the value must be set to match the previous value. This can be done by setting `nameOverride=infra`._
 

--- a/charts/infra-server/templates/NOTES.txt
+++ b/charts/infra-server/templates/NOTES.txt
@@ -8,4 +8,17 @@ Access Infra server by running the following command in a shell:
 Afterwards, open https://localhost:8443 in a browser.
 {{- end }}
 
+{{- if .Values.config.initialUser }}
+
+In the dashboard, login with user "admin@local". The password can be found
+by running the following command in a shell:
+
+  kubectl -n {{ .Release.Namespace }} get secret {{ include "server.fullname" . | printf "%s-initial-admin-secret" }} -o jsonpath='{.data.password}' | base64 -d
+
+Once logged in, you should replace the initial admin user with your own
+user or connect an identity provider.
+
+The initial admin user can be disabled with `config.admin.enabled=false`.
+{{- end }}
+
 Visit https://infrahq.com for more information on Infra server.

--- a/charts/infra-server/templates/server/configmap.yaml
+++ b/charts/infra-server/templates/server/configmap.yaml
@@ -31,6 +31,16 @@ data:
 {{- $_ := set $config.tls "caPrivateKey" "file:/var/run/secrets/infrahq.com/certificate-authority/ca.key" }}
 {{- end }}
 
+{{- $config := unset $config "users" }}
+{{- $config := unset $config "providers" }}
+{{- $config := unset $config "grants" }}
+{{- $config := unset $config "secrets" }}
+
+{{- if .Values.config.admin.enabled }}
+{{- $_ := set $config "users" (list (dict "name" "admin@local" "password" "file:/var/run/secrets/infrahq.com/initial-admin-secret/password")) }}
+{{- $_ := set $config "grants" (list (dict "user" "admin@local" "role" "admin" "resource" "infra")) }}
+{{- end }}
+
 {{- range $key, $val := $config }}
 {{- if kindIs "invalid" $val }}
 {{- else if kindIs "map" $val }}

--- a/charts/infra-server/templates/server/deployment.yaml
+++ b/charts/infra-server/templates/server/deployment.yaml
@@ -63,6 +63,11 @@ spec:
               mountPath: /var/run/secrets/infrahq.com/encryption-key
               readOnly: true
 {{- end }}
+{{- if .Values.config.admin.enabled }}
+            - name: initial-admin-secret
+              mountPath: /var/run/secrets/infrahq.com/initial-admin-secret
+              readOnly: true
+{{- end }}
 {{- if .Values.server.volumeMounts }}
 {{- .Values.server.volumeMounts | toYaml | nindent 12 }}
 {{- end }}
@@ -126,6 +131,11 @@ spec:
         - name: encryption-key
           secret:
             secretName: {{ include "server.fullname" . }}-encryption-key
+{{- end }}
+{{- if .Values.config.admin.enabled }}
+        - name: initial-admin-secret
+          secret:
+            secretName: {{ include "server.fullname" . }}-initial-admin-secret
 {{- end }}
 {{- if .Values.server.volumes }}
 {{- .Values.server.volumes | toYaml | nindent 8 }}

--- a/charts/infra-server/templates/server/secret.yaml
+++ b/charts/infra-server/templates/server/secret.yaml
@@ -39,3 +39,19 @@ data:
   key: {{ randAlphaNum 32 | b64enc }}
 {{- end }}
 {{- end }}
+---
+{{- if .Values.config.admin.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "server.fullname" . }}-initial-admin-secret
+  labels:
+{{- include "server.labels" . | nindent 4 }}
+data:
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (printf "%s-initial-admin-secret" (include "server.fullname" .)) -}}
+{{- if $secret.data }}
+  password: {{ $secret.data.password }}
+{{- else }}
+  password: {{ randAlphaNum 16 | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/infra-server/values.yaml
+++ b/charts/infra-server/values.yaml
@@ -16,6 +16,10 @@ config:
   ui:
     proxyURL: ""
 
+  admin:
+    ## Enable initial admin user
+    enabled: true
+
   ## Database host.
   ## If omitted, a database will be automatically configured
   dbHost: ""
@@ -68,67 +72,6 @@ config:
     # ## Path to certificate and private key
     # certificate: ""
     # privateKey: ""
-
-  ## Additional users to configure
-  users: []
-    ## Configure a user with an access key
-    # - name: ""      # required
-    #   accessKey: "" # optional, can be specified as a secret. must be in the form of XXXXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYY (<10 character ascii key>.<24 character ascii secret>)
-    #   password: ""  # optional, can be specified as a secret
-
-    ## Example
-    # Create an "admin" user
-    # - name: admin
-
-    ## Create an "admin" user and seed an access key passed in as an environment variable
-    # The environment variable will need to be injected into the pod using `env` or `envFrom`
-    # - name: admin
-    #   accessKey: env:ADMIN_ACCESS_KEY
-
-    ## Create a "dev@example.com" user
-    # - name: dev@example.com
-
-    ## Create a "dev@example.com" user and set a password passed in as a file. The file will need
-    # to be mounted into the pod using `volumes` and `volumeMounts`
-    # - name: dev@example.com
-    #   password: file:/var/run/secrets/dev@example.com
-
-  ## Additional identity providers to configure
-  providers: []
-    # - name: ""          # required, to be referenced when creating grants
-    #   url: ""           # required
-    #   clientID: ""      # required
-    #   clientSecret: ""  # required
-
-    ## Example
-    # Configure Okta as an identity provider
-    # - name: Okta
-    #   url: example.okta.com
-    #   clientID: myoktaclientid
-    #   clientSecret: env:OKTA_CLIENT_SECRET
-
-  ## Additional grants to configure
-  grants: []
-    # - user: ""      # one of ['user', 'group'] is required
-    #   group: ""     # one of ['user', 'group'] is required
-    #   resource: ""  # required, resource being granted access
-    #   role: ""      # optional, if omitted, Infra will only grant authentication to the resource
-
-    ## Example
-    # Grant user 'admin@example.com' Infra admin
-    # - user: admin@example.com
-    #   role: admin
-    #   resource: infra
-
-    ## Grant user 'admin@example.com' edit to Kubernetes cluster 'docker-desktop'
-    # - user: admin@example.com
-    #   role: edit
-    #   resource: kubernetes.docker-desktop
-
-    ## Grant group 'Everyone' view to Kubernetes cluster 'docker-desktop', namespace 'default'
-    # - group: Everyone
-    #   role: view
-    #   resource: kubernetes.docker-desktop.default
 
 ## Global configurations
 global:


### PR DESCRIPTION
- remove users, grants, provider as general purpose configuration. users are encouraged to use the [Terraform provider][1] instead
- add an `initialUser` configuration to allow users to bootstrap their server deployment

[1]: https://registry.terraform.io/providers/infrahq/infra