### PR TITLE
fix(infra): labels, podLabels, and podAnnotations

### DIFF
--- a/charts/infra-server/ci/test-values.yaml
+++ b/charts/infra-server/ci/test-values.yaml
@@ -1,0 +1,39 @@
+global:
+  labels:
+    global-label: value
+
+  podLabels:
+    global-pod-label: value
+
+  podAnnotations:
+    global-pod-annotation: value
+
+server:
+  labels:
+    server-label: value
+
+  podLabels:
+    server-pod-label: value
+
+  podAnnotations:
+    server-pod-annotation: value
+
+ui:
+  labels:
+    ui-label: value
+
+  podLabels:
+    ui-pod-label: value
+
+  podAnnotations:
+    ui-pod-annotation: value
+
+postgres:
+  labels:
+    postgres-label: value
+
+  podLabels:
+    postgres-pod-label: value
+
+  podAnnotations:
+    postgres-pod-annotation: value

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: infra
 description: A Helm chart for Infra connector. For Infra server charts, use infra-server.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.19.0

--- a/charts/infra/ci/access-key-values.yaml
+++ b/charts/infra/ci/access-key-values.yaml
@@ -3,5 +3,14 @@ config:
   server:
     url: localhost
 
+labels:
+  label: value
+
+podLabels:
+  pod-label: value
+
+podAnnotations:
+  pod-annotation: value
+
 service:
   type: ClusterIP

--- a/charts/infra/templates/_helpers.tpl
+++ b/charts/infra/templates/_helpers.tpl
@@ -42,6 +42,9 @@ app.infrahq.com/component: connector
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -69,7 +72,7 @@ Pod labels
 {{- define "connector.podLabels" -}}
 {{- include "connector.selectorLabels" . }}
 {{- if .Values.podLabels }}
-{{- toYaml .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
 {{- end }}
 {{- end }}
 
@@ -79,6 +82,6 @@ Pod annotations
 {{- define "connector.podAnnotations" -}}
 rollme: {{ include (print .Template.BasePath "/configmap.yaml") . | sha1sum }}
 {{- if .Values.podAnnotations }}
-{{- toYaml .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`labels`, `podLabels,` and `podAnnotations` templates potentially multiple sources of key-values. Squashing the newline with `{{- ... }}` creates invalid YAML

add tests to check this for both the infra chart and the infra-server chart

bump infra chart version to 0.1.1