### PR TITLE
Add config.logLevel to values.yaml

### DIFF
--- a/charts/infra-server/Chart.yaml
+++ b/charts/infra-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: infra-server
 description: A Helm chart for Infra server.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.21.0

--- a/charts/infra-server/values.yaml
+++ b/charts/infra-server/values.yaml
@@ -94,8 +94,8 @@ global:
 
   ## Environment variables to pass to all deployed pods
   env: []
-    # - name: "INFRA_LOG_LEVEL"
-    #   value: "info"
+    # - name: "HTTP_PROXY"
+    #   value: "foo"
 
   ## ConfigMap or Secret references containing environment variables to pass to all deploy pods
   ## Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
@@ -140,8 +140,8 @@ server:
 
   ## Environment variables to pass to the server container
   env: []
-    # - name: "INFRA_LOG_LEVEL"
-    #   value: "info"
+    # - name: "HTTP_PROXY"
+    #   value: "foo"
 
   ## ConfigMap or Secret references containing environment variables to pass to the server container
   ## Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
@@ -643,8 +643,8 @@ postgres:
 
   ## Environment variables to pass to the postgres container
   env: []
-    # - name: "INFRA_LOG_LEVEL"
-    #   value: "info"
+    # - name: "HTTP_PROXY"
+    #   value: "foo"
 
   ## ConfigMap or Secret references containing environment variables to pass to the postgres container
   ## Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

--- a/charts/infra-server/values.yaml
+++ b/charts/infra-server/values.yaml
@@ -52,6 +52,10 @@ config:
   ## Enable telemetry collection
   enableTelemetry: true
 
+  ## Log Level of the server
+  ## [error, warn, info, debug] (default info)
+  logLevel: info
+
   ## Duration of a user session
   ## Default 30 days
   sessionDuration: 720h0m0s


### PR DESCRIPTION
This patch makes it more intuitive to set the server's logLevel.

I initially got confused by this not being in the `values.yaml` file. (#24)