### PR TITLE
feat: allow to use CertManager for CA generation

### DIFF
--- a/charts/infra/templates/certificate.yaml
+++ b/charts/infra/templates/certificate.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.config.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "connector.fullname" . }}
+  labels:
+{{- include "connector.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "connector.fullname" . }}
+  labels:
+{{- include "connector.labels" . | nindent 4 }}
+spec:
+  commonName: infra-connector
+  duration: 2160h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: {{ include "connector.fullname" . }}
+  privateKey:
+    rotationPolicy: Always
+  renewBefore: 36h0m0s
+  secretName: {{ include "connector.fullname" . | printf "%s-certificate-authority"  }}
+  usages:
+    - server auth
+    - client auth
+{{- end }}

--- a/charts/infra/templates/deployment.yaml
+++ b/charts/infra/templates/deployment.yaml
@@ -101,6 +101,13 @@ spec:
         - name: certificate-authority
           secret:
             secretName: {{ include "connector.fullname" . }}-certificate-authority
+            {{- if .Values.config.useCertManager }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.key
+                path: ca.key
+            {{- end }}
         - name: access-key
           secret:
 {{- if .Values.config.accessKey }}

--- a/charts/infra/templates/secret.yaml
+++ b/charts/infra/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.config.useCertManager }}
+{{- if not .Values.config.useCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/infra/templates/secret.yaml
+++ b/charts/infra/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.config.useCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,6 +19,7 @@ data:
   ca.key: |
 {{- $ca.Key | b64enc | nindent 4 }}
 {{- end }} {{/* if secret.data */}}
+{{- end }}
 ---
 {{- if .Values.config.accessKey }}
 apiVersion: v1

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -35,6 +35,9 @@ config:
     ## PEM encoded CA certificate of the server
     trustedCertificate: ""
 
+  # Use cert-manager to manage certificate
+  useCertManager: false
+
   ## Path to CA and private key
   caCert: /var/run/secrets/infrahq.com/certificate-authority/ca.crt
   caKey: /var/run/secrets/infrahq.com/certificate-authority/ca.key


### PR DESCRIPTION
when we use ArgoCD the application is always in out of sync status because argocd render templates every reconciling time and can't use lookup